### PR TITLE
#56 HTTP 모의 요청(REST client)

### DIFF
--- a/example.http
+++ b/example.http
@@ -1,0 +1,58 @@
+# 롤링 리스트 GET request
+GET https://rolling-api.vercel.app/11-2/recipients/ HTTP/1.1
+
+###
+
+# 롤링 리스트 POST request
+POST https://rolling-api.vercel.app/11-2/recipients/ HTTP/1.1
+Content-Type: application/json;
+
+{
+  "team": "11-2",
+  "name": "테스트 롤링 등록",
+  "backgroundColor": "blue"
+}
+
+###
+# 롤링 메세지 GET request
+GET https://rolling-api.vercel.app/11-2/recipients/9075/messages/ HTTP/1.1
+
+###
+# 롤링 메세지 POST request
+POST https://rolling-api.vercel.app/11-2/recipients/9075/messages/ HTTP/1.1
+Content-Type: application/json;
+
+{
+  "team": "11-2",
+  "recipientId" : "9075",
+  "sender": "테스트 메세지 등록",
+  "profileImageURL" : "http://via.placeholder.com/100x100",
+  "relationship" : "친구",
+  "content" : "메세지 테스트 중 입니다",
+  "font" : "Pretendard"
+}
+
+###
+# 롤링 이모지 GET request
+GET https://rolling-api.vercel.app/11-2/recipients/9075/reactions/ HTTP/1.1
+
+###
+# 롤링 이모지 POST request(증가)
+POST https://rolling-api.vercel.app/11-2/recipients/9075/reactions/ HTTP/1.1
+Content-Type: application/json;
+
+{
+"emoji" : "🧪",
+"type" : "increase"
+}
+
+###
+# 롤링 이모지 POST request(감소)
+POST https://rolling-api.vercel.app/11-2/recipients/9075/reactions/ HTTP/1.1
+Content-Type: application/json;
+
+{
+"emoji" : "🧪",
+"type" : "decrease"
+}
+


### PR DESCRIPTION
API 테스트를 위한 HTTP 모의 요청 가능한 문서 작성

### 이슈 번호 

resolve #56 

### 변경 사항 요약 

- HTTP 요청을 vscode안에서 간단하게 모의 테스트 해볼 수 있게 작성하였습니다.
- [테스트 response 받는 법](https://www.codeit.kr/tutorials/37/REST-Client-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)
- [Rest Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) vscode 확장 플러그인 필요


### 테스트 결과 

- [x] 정상적인 상태를 반환하는지 테스트
![스크린샷 2024-10-27 오후 12 19 23](https://github.com/user-attachments/assets/ce346629-1d8b-43b5-bb9d-ebfdef816f8e)

