### PR TITLE
#60 Feature/#60 공통컴포넌트   button

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,9 @@ module.exports = {
       jsx: true, // JSX를 사용할 수 있도록 설정
     },
     requireConfigFile: false, // 별도의 Babel 설정 파일을 요구하지 않도록 설정
+    babelOptions: {
+      presets: ['@babel/preset-react'], // React 프리셋 사용
+    },
   },
 
   extends: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,6 @@ module.exports = {
       jsx: true, // JSX를 사용할 수 있도록 설정
     },
     requireConfigFile: false, // 별도의 Babel 설정 파일을 요구하지 않도록 설정
-    babelOptions: {
-      presets: ['@babel/preset-react'], // React 프리셋 사용
-    },
   },
 
   extends: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0",
         "react-scripts": "^5.0.1",
         "styled-components": "^6.1.13",
         "web-vitals": "^2.1.4"
@@ -3309,6 +3310,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15153,6 +15162,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0",
     "react-scripts": "^5.0.1",
     "styled-components": "^6.1.13",
     "web-vitals": "^2.1.4"

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { StButton } from './Button.styles';
+
+function Button({
+  size = 's',
+  color = 'primary',
+  onClick,
+  children,
+  disabled = false,
+}) {
+  return (
+    <StButton size={size} color={color} onClick={onClick} disabled={disabled}>
+      {children}
+    </StButton>
+  );
+}
+
+Button.propTypes = {
+  size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
+  color: PropTypes.oneOf(['primary', 'secondary']),
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+export default Button;

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,17 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { StButton } from './Button.styles';
 
-function Button({
-  size = 's',
-  color = 'primary',
-  onClick,
-  children,
-  disabled = false,
-}) {
+function Button({ size, color, onClick, children, disabled, type, to }) {
+  const TAG = to ? Link : 'button';
   return (
-    <StButton size={size} color={color} onClick={onClick} disabled={disabled}>
+    <StButton
+      size={size}
+      color={color}
+      onClick={onClick}
+      disabled={disabled}
+      as={TAG}
+      {...(TAG === Link && { to })}
+      type={TAG === 'button' ? type : undefined}
+    >
       {children}
     </StButton>
   );
@@ -23,6 +27,16 @@ Button.propTypes = {
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  to: PropTypes.string,
+};
+
+Button.defaultProps = {
+  size: 's',
+  color: 'primary',
+  onClick: () => {},
+  disabled: false,
+  type: 'button',
 };
 
 export default Button;

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -4,7 +4,25 @@ import { Link } from 'react-router-dom';
 
 import { StButton } from './Button.styles';
 
-function Button({ size, color, onClick, children, disabled, type, to }) {
+Button.propTypes = {
+  size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
+  color: PropTypes.oneOf(['primary', 'secondary']),
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  to: PropTypes.string,
+};
+
+function Button({
+  size = 's',
+  color = 'primary',
+  onClick = () => {},
+  children,
+  disabled = false,
+  type = 'button',
+  to,
+}) {
   const TAG = to ? Link : 'button';
   return (
     <StButton
@@ -20,23 +38,5 @@ function Button({ size, color, onClick, children, disabled, type, to }) {
     </StButton>
   );
 }
-
-Button.propTypes = {
-  size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
-  color: PropTypes.oneOf(['primary', 'secondary']),
-  onClick: PropTypes.func,
-  disabled: PropTypes.bool,
-  children: PropTypes.node.isRequired,
-  type: PropTypes.oneOf(['button', 'submit', 'reset']),
-  to: PropTypes.string,
-};
-
-Button.defaultProps = {
-  size: 's',
-  color: 'primary',
-  onClick: () => {},
-  disabled: false,
-  type: 'button',
-};
 
 export default Button;

--- a/src/components/Button/Button.styles.js
+++ b/src/components/Button/Button.styles.js
@@ -1,0 +1,89 @@
+import styled, { css } from 'styled-components';
+
+const sizes = {
+  s: css`
+    padding: 13px 20px;
+    border-radius: 6px;
+    font-size: 16px;
+  `,
+  m: css`
+    width: 120px;
+    height: 40px;
+    border-radius: 6px;
+    font-size: 16px;
+  `,
+  l: css`
+    width: 280px;
+    height: 56px;
+    border-radius: 12px;
+    font-size: 18px;
+    font-weight: bold;
+  `,
+  xl: css`
+    width: 100%;
+    height: 56px;
+    border-radius: 12px;
+    font-size: 18px;
+    font-weight: bold;
+  `,
+};
+
+const colors = {
+  primary: css`
+    border: none;
+    background-color: #9935ff;
+    color: #ffffff;
+
+    &:hover {
+      background-color: #861dee;
+    }
+    &:active,
+    &:focus:active {
+      background-color: #6e0ad1;
+    }
+    &:focus {
+      background-color: #6e0ad1;
+      outline: none;
+    }
+    &:disabled {
+      background-color: #cccccc;
+      cursor: not-allowed;
+    }
+  `,
+  secondary: css`
+    border: 1px solid #9935ff;
+    background-color: #ffffff;
+    color: #861dee;
+
+    &:hover {
+      border-color: #861dee;
+      background-color: #f7f0ff;
+      color: #9935ff;
+    }
+    &:active,
+    &:focus:active {
+      border-color: #6e0ad1;
+      background-color: #f7f0ff;
+      color: #9935ff;
+    }
+    &:focus {
+      border-color: #6e0ad1;
+      background-color: #ffffff;
+      color: #9747ff;
+      outline: none;
+    }
+    &:disabled {
+      border: none;
+      background-color: #cccccc;
+      color: #ffffff;
+      cursor: not-allowed;
+    }
+  `,
+};
+
+export const StButton = styled.button`
+  transition: all 0.3s ease;
+
+  ${({ size }) => sizes[size]}
+  ${({ color }) => colors[color]}
+`;

--- a/src/components/Button/Button.styles.js
+++ b/src/components/Button/Button.styles.js
@@ -4,26 +4,26 @@ const sizes = {
   s: css`
     padding: 13px 20px;
     border-radius: 6px;
-    font-size: 1rem;
+    font-size: 1.6rem;
   `,
   m: css`
     width: 120px;
     height: 40px;
     border-radius: 6px;
-    font-size: 1rem;
+    font-size: 1.6rem;
   `,
   l: css`
     width: 280px;
     height: 56px;
     border-radius: 12px;
-    font-size: 1.125rem;
+    font-size: 1.8rem;
     font-weight: bold;
   `,
   xl: css`
     width: 100%;
     height: 56px;
     border-radius: 12px;
-    font-size: 1.125rem;
+    font-size: 1.8rem;
     font-weight: bold;
   `,
 };

--- a/src/components/Button/Button.styles.js
+++ b/src/components/Button/Button.styles.js
@@ -4,26 +4,26 @@ const sizes = {
   s: css`
     padding: 13px 20px;
     border-radius: 6px;
-    font-size: 16px;
+    font-size: 1rem;
   `,
   m: css`
     width: 120px;
     height: 40px;
     border-radius: 6px;
-    font-size: 16px;
+    font-size: 1rem;
   `,
   l: css`
     width: 280px;
     height: 56px;
     border-radius: 12px;
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: bold;
   `,
   xl: css`
     width: 100%;
     height: 56px;
     border-radius: 12px;
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: bold;
   `,
 };
@@ -82,6 +82,10 @@ const colors = {
 };
 
 export const StButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
   transition: all 0.3s ease;
 
   ${({ size }) => sizes[size]}


### PR DESCRIPTION
### 이슈 번호 

close #60

### 변경 사항 요약 

공통컴포넌트 추가했습니다.

## Props
| **Prop**  | **Type**   | **Description** |
|-----------|------------|-----------------|
| `size`    | `string`   | s, m, l, xl |
| `color`   | `string`   | primary, secondary |
| `onClick` | `func`     | - |
| `disabled` | `boolean`  | (옵션) |


### 테스트 결과 
size, color, onClick 함수, disabled props들 정상적으로 받아서 작동되는지 확인완료
호버, 포커싱, 액티브 상태에 따른 변화 정상적인 작동 확인 완료

ex) 결과물에 대한 스크린 샷
![image](https://github.com/user-attachments/assets/6bc04b92-3ced-4f0f-a436-d7aa9c6b24c4)

### 추가요청사항 반영
1.
props으로 받는 type 속성과 to 속성을 추가하였습니다.
to 속성을 받을때는 Link 태그로 변경되고, 안받을때는 기본적으로 button 타입의 button 태그입니다.
Link 태그로 변경될떄는 일관된 스타일이 유지가 안되서 기본적인 스타일링을 추가하였습니다. 
Link 태그를 사용하기위해 react-router-dom 패키지를 설치하였습니다.

| **Prop**  | **Type**   | **Description** |
|-----------|------------|-----------------|
|`to` |`string` |라우터경로 ex) "/list"|
| `type`    | `string`   |submit, button, reset |

2. 
px로 작업된 폰트크기를 rem으로 변경하였습니다.

3. 
props의 기본값을 구조분해할당안에서 지정했던걸 따로 디폴트프롭으로 분리하였습니다.
![image](https://github.com/user-attachments/assets/b7b5e49b-3202-4bdf-b370-929eb86bfca7)
