### PR TITLE
#75 � jsx파싱에러관련 eslintrc.js파일에서 module.exports에 해당옵션 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,9 @@ module.exports = {
       jsx: true, // JSX를 사용할 수 있도록 설정
     },
     requireConfigFile: false, // 별도의 Babel 설정 파일을 요구하지 않도록 설정
+    babelOptions: {
+      presets: ['@babel/preset-react'], // React 프리셋 사용
+    },
   },
 
   extends: [


### PR DESCRIPTION
### 이슈 번호 

close #75

### 변경 사항 요약 

eslintrc.js 파일에서 module.exports 항목에
babelOptions 항목과 presets: ['@babel/preset-react'] 옵션 추가하였습니다. 
해당 옵션의 역할은 React JSX 문법과 최신 JavaScript 기능을 일반 JavaScript로 변환시켜주는 옵션입니다.


### 테스트 결과 
해당 옵션 추가하니 jsx파일에서 뜨던 파싱에러 경고가 더이상 뜨지않음을 확인

### 결과물에 대한 스크린 샷
![image](https://github.com/user-attachments/assets/419edca7-7748-46e8-89cd-88ce5c07ea1a)
