### PR TITLE
#84 ✨ 공통 컴포넌트 - ArrowButton 작업

### DIFF
--- a/src/components/ArrowButton/ArrowButton.jsx
+++ b/src/components/ArrowButton/ArrowButton.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { ArrowArea, Arrow } from './ArrowButton.styles';
+
+ArrowButton.propTypes = {
+  direction: PropTypes.oneOf(['left', 'right']),
+  onClick: PropTypes.func,
+};
+
+function ArrowButton({ direction = 'right', onClick = () => {} }) {
+  return (
+    <ArrowArea onClick={onClick} type="button">
+      <Arrow direction={direction} />
+    </ArrowArea>
+  );
+}
+
+export default ArrowButton;

--- a/src/components/ArrowButton/ArrowButton.styles.js
+++ b/src/components/ArrowButton/ArrowButton.styles.js
@@ -6,7 +6,6 @@ export const ArrowArea = styled.button`
   border-radius: 50%;
   background-color: white;
   border: 1px solid ${({ theme }) => theme.colorTheme.grayscale[200]};
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ArrowButton/ArrowButton.styles.js
+++ b/src/components/ArrowButton/ArrowButton.styles.js
@@ -1,0 +1,37 @@
+import styled, { css } from 'styled-components';
+
+export const ArrowArea = styled.button`
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  background-color: white;
+  border: 1px solid ${({ theme }) => theme.colorTheme.grayscale[200]};
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s;
+
+  &:hover {
+    transform: scale(1.02);
+  }
+  &:active {
+    transform: scale(0.97);
+  }
+`;
+
+export const Arrow = styled.div`
+  width: 1rem;
+  height: 1rem;
+  border-right: 2px solid ${({ theme }) => theme.colorTheme.black};
+  border-bottom: 2px solid ${({ theme }) => theme.colorTheme.black};
+
+  ${(props) =>
+    props.direction === 'left'
+      ? css`
+          transform: rotate(135deg);
+        `
+      : css`
+          transform: rotate(-45deg);
+        `}
+`;


### PR DESCRIPTION
### 이슈 번호 

close #84

### 변경 사항 요약 

롤링페이퍼 페이지에서 카드를 좌우로 넘기는 화살표버튼 컴포넌트입니다.

| Prop       | Type   | Description                                      |
|------------|--------|--------------------------------------------------|
| `direction` | string | `'left'` 또는 `'right'`를 받아 해당 방향의 화살표로 표시합니다. |
| `onClick`   | func   | - |

left, right에 따라 왼쪽, 오른쪽 두방향을 지원합니다.
클릭할떄 누르는것을 알수있도록 약간의 모션을 추가했습니다.


### 테스트 결과 
정상적으로 작동 되는것을 확인했습니다.

### 결과물에 대한 스크린 샷
![image](https://github.com/user-attachments/assets/8cf585e0-f082-454a-b81c-32d0f70c06fa)
