### PR TITLE
#92 ✨ 공통컴포넌트 - TabToggle 작업

### DIFF
--- a/src/components/TabToggle/TabToggle.jsx
+++ b/src/components/TabToggle/TabToggle.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+import { TabToggleArea, TabButton, SelectedTab } from './TabToggle.styles';
+
+TabToggle.propTypes = {
+  tabs: PropTypes.arrayOf(PropTypes.string),
+  onClick: PropTypes.func,
+};
+
+function TabToggle({ tabs = ['컬러', '이미지'], onClick = () => {} }) {
+  const [currentTab, setCurrentTab] = useState(tabs[0]);
+
+  const handleTabClick = (tab) => {
+    setCurrentTab(tab);
+  };
+
+  return (
+    <TabToggleArea tabLength={tabs.length}>
+      <SelectedTab selectedIndex={tabs.indexOf(currentTab)} />
+      {tabs.map((tab) => (
+        <TabButton
+          key={tab}
+          isSelected={currentTab === tab}
+          onClick={() => handleTabClick(tab)}
+        >
+          {tab}
+        </TabButton>
+      ))}
+    </TabToggleArea>
+  );
+}
+
+export default TabToggle;

--- a/src/components/TabToggle/TabToggle.styles.js
+++ b/src/components/TabToggle/TabToggle.styles.js
@@ -5,7 +5,7 @@ export const TabToggleArea = styled.div`
   position: relative;
   width: ${({ tabLength }) => `${12 * tabLength}rem`};
   height: 4rem;
-  background-color: #f6f6f6;
+  background-color: ${({ theme }) => theme.colorTheme.grayscale[100]};
   border-radius: 6px;
   overflow: hidden;
 `;

--- a/src/components/TabToggle/TabToggle.styles.js
+++ b/src/components/TabToggle/TabToggle.styles.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+export const TabToggleArea = styled.div`
+  display: flex;
+  position: relative;
+  width: ${({ tabLength }) => `${12 * tabLength}rem`};
+  height: 4rem;
+  background-color: #f6f6f6;
+  border-radius: 6px;
+  overflow: hidden;
+`;
+
+export const TabButton = styled.button`
+  width: 12rem;
+  height: 100%;
+  border: none;
+  background: transparent;
+  ${({ theme, isSelected }) =>
+    isSelected ? theme.fontTheme['16Bold'] : theme.fontTheme['16Regular']};
+  color: ${({ isSelected, theme }) =>
+    isSelected
+      ? theme.colorTheme.purple[600]
+      : theme.colorTheme.grayscale[900]};
+  z-index: 1;
+`;
+
+export const SelectedTab = styled.div`
+  position: absolute;
+  top: 0;
+  left: ${({ selectedIndex }) => `${12 * selectedIndex}rem`};
+  width: 12rem;
+  height: 100%;
+  border: 2px solid ${({ theme }) => theme.colorTheme.purple[600]};
+  border-radius: 6px;
+  transition: left 0.3s ease;
+`;


### PR DESCRIPTION
### 이슈 번호 

close #92

### 변경 사항 요약 

롤링페이퍼 생성페이지에서 사용되는 탭 토글메뉴입니다.

### Props
| Prop  | Type    | desc |
|-----------|---------|---------|
| `onClick`   | `func` | - |
| `tabs`      | `array[string]`  | - |

확장성을 고려해서 탭 항목을 배열로 받을수 있게 만들었습니다.
탭 메뉴 이동은 자체 스테이트로 관리되므로 
onClick을 통해서 현재 탭을 추적하고 추가적인 함수기능을 받아 수행할수 있어용.


### 테스트 결과 
탭토글 정상적으로 작동되는것 확인

### 결과물에 대한 스크린 샷
![image](https://github.com/user-attachments/assets/99b33503-e304-41eb-927e-cc5611ba3c60)
