### PR TITLE
#110 유저 정보 컴포넌트

### DIFF
--- a/src/pages/MessagesList/MessagesHeader.jsx
+++ b/src/pages/MessagesList/MessagesHeader.jsx
@@ -1,6 +1,12 @@
-import { Profiler } from 'react';
-import Badge from '../../components/Badge/Badge';
 import PropTypes from 'prop-types';
+import { styled } from 'styled-components';
+
+import Badge from '../../components/Badge/Badge';
+import Profile from '../../components/Profile/Profile';
+import dateConversion from '../../utils/dateConversion';
+
+const HeaderContainer = styled.div``;
+const HeaderArea = styled.div``;
 
 MessagesHeader.propTypes = {
   name: PropTypes.string,
@@ -15,12 +21,12 @@ MessagesHeader.propTypes = {
 function MessagesHeader({
   name,
   badgeValue,
-  profiler = { imageUrl, size },
+  profiler = { imageUrl: '', size: '' },
   createdAt,
 }) {
   return (
     <HeaderContainer>
-      <Profiler imageUrl={profiler.imageUrl} size={profiler.size} />
+      <Profile imageUrl={profiler.imageUrl} size={profiler.size} />
       <HeaderArea>
         <h3>
           <span>From.</span>
@@ -28,7 +34,7 @@ function MessagesHeader({
         </h3>
         <Badge value={badgeValue} />
       </HeaderArea>
-      {createdAt && <span>{createdAt}</span>}
+      {createdAt && <span>{dateConversion(createdAt)}</span>}
     </HeaderContainer>
   );
 }

--- a/src/pages/MessagesList/MessagesHeader.jsx
+++ b/src/pages/MessagesList/MessagesHeader.jsx
@@ -11,7 +11,7 @@ import dateConversion from '../../utils/dateConversion';
 
 MessagesHeader.propTypes = {
   name: PropTypes.string.isRequired,
-  badgeValue: PropTypes.string,
+  badgeValue: PropTypes.oneOf(['친구', '가족', '동료', '지인']),
   profiler: PropTypes.shape({
     imageUrl: PropTypes.string.isRequired,
     size: PropTypes.string,

--- a/src/pages/MessagesList/MessagesHeader.jsx
+++ b/src/pages/MessagesList/MessagesHeader.jsx
@@ -10,10 +10,10 @@ import Profile from '../../components/Profile/Profile';
 import dateConversion from '../../utils/dateConversion';
 
 MessagesHeader.propTypes = {
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   badgeValue: PropTypes.string,
   profiler: PropTypes.shape({
-    imageUrl: PropTypes.string,
+    imageUrl: PropTypes.string.isRequired,
     size: PropTypes.string,
   }),
   createdAt: PropTypes.string,

--- a/src/pages/MessagesList/MessagesHeader.jsx
+++ b/src/pages/MessagesList/MessagesHeader.jsx
@@ -1,0 +1,36 @@
+import { Profiler } from 'react';
+import Badge from '../../components/Badge/Badge';
+import PropTypes from 'prop-types';
+
+MessagesHeader.propTypes = {
+  name: PropTypes.string,
+  badgeValue: PropTypes.string,
+  profiler: PropTypes.shape({
+    imageUrl: PropTypes.string,
+    size: PropTypes.string,
+  }),
+  createdAt: PropTypes.string,
+};
+
+function MessagesHeader({
+  name,
+  badgeValue,
+  profiler = { imageUrl, size },
+  createdAt,
+}) {
+  return (
+    <HeaderContainer>
+      <Profiler imageUrl={profiler.imageUrl} size={profiler.size} />
+      <HeaderArea>
+        <h3>
+          <span>From.</span>
+          {name}
+        </h3>
+        <Badge value={badgeValue} />
+      </HeaderArea>
+      {createdAt && <span>{createdAt}</span>}
+    </HeaderContainer>
+  );
+}
+
+export default MessagesHeader;

--- a/src/pages/MessagesList/MessagesHeader.jsx
+++ b/src/pages/MessagesList/MessagesHeader.jsx
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
-import { styled } from 'styled-components';
 
+import {
+  HeaderContainer,
+  HeaderArea,
+  HeaderPosition,
+} from './MessagesHeader.styles.js';
 import Badge from '../../components/Badge/Badge';
 import Profile from '../../components/Profile/Profile';
 import dateConversion from '../../utils/dateConversion';
-
-const HeaderContainer = styled.div``;
-const HeaderArea = styled.div``;
 
 MessagesHeader.propTypes = {
   name: PropTypes.string,
@@ -19,21 +20,23 @@ MessagesHeader.propTypes = {
 };
 
 function MessagesHeader({
-  name,
-  badgeValue,
+  name = '보낸이',
+  badgeValue = '친구',
   profiler = { imageUrl: '', size: '' },
-  createdAt,
+  createdAt = '',
 }) {
   return (
     <HeaderContainer>
-      <Profile imageUrl={profiler.imageUrl} size={profiler.size} />
-      <HeaderArea>
-        <h3>
-          <span>From.</span>
-          {name}
-        </h3>
-        <Badge value={badgeValue} />
-      </HeaderArea>
+      <HeaderPosition>
+        <Profile imageURL={profiler.imageUrl} size={profiler.size} />
+        <HeaderArea>
+          <h3>
+            <span>From.</span>
+            {name}
+          </h3>
+          <Badge value={badgeValue} />
+        </HeaderArea>
+      </HeaderPosition>
       {createdAt && <span>{dateConversion(createdAt)}</span>}
     </HeaderContainer>
   );

--- a/src/pages/MessagesList/MessagesHeader.styles.js
+++ b/src/pages/MessagesList/MessagesHeader.styles.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const HeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  > span {
+    ${({ theme }) => theme.fontTheme['14Regular']};
+    color: ${({ theme }) => theme.colorTheme.grayscale[500]};
+  }
+`;
+export const HeaderPosition = styled.div`
+  display: flex;
+  gap: 1.4rem;
+  flex: 1;
+`;
+export const HeaderArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  h3 {
+    margin-bottom: 0.6rem;
+    ${({ theme }) => theme.fontTheme['20Regular']}
+    span {
+      margin-right: 0.6rem;
+      ${({ theme }) => theme.fontTheme['20Bold']}
+    }
+  }
+`;


### PR DESCRIPTION
### 이슈 번호 

close #110 

### 변경 사항 요약 
- 메세지 헤더 컴포넌트 입니다.

props | types | desc 
-- | -- | --
*name |string| '보낸이'  
badgeValue | oneOf | [친구,가족,동료,지인] 
profiler | shape | Profiler 컴포넌트에 전달할 props  
ㄴ*imageUrl | string | 유저 이미지 URL
ㄴsize | string | 유저 프로필 사이즈
createdAt | string | 생성 날짜


### 테스트 결과 
![스크린샷 2024-10-29 오후 2 58 51](https://github.com/user-attachments/assets/aebbc207-30f2-4721-bd04-43ad9871c438)
