### PR TITLE
✨ 테마 컬러와 폰트 쉽게 쓰는 유틸 함수 기능!

### DIFF
--- a/src/pages/RecipientsList/RecipientsList.jsx
+++ b/src/pages/RecipientsList/RecipientsList.jsx
@@ -107,8 +107,7 @@ function RecipientsList({ favorite = false }) {
           prevEl: isPC ? '.swiper-button-prev' : undefined,
         }}
         // 디바이스 조건에 따른 터치 스와이프 가능 여부
-        allowTouchMove={isTablet || isMobile}
-      >
+        allowTouchMove={isTablet || isMobile}>
         {rollingList.map((item) => (
           <SwiperSlide key={item.id}>
             <RecipientCard

--- a/src/utils/themeUtils.js
+++ b/src/utils/themeUtils.js
@@ -1,0 +1,66 @@
+/**
+ * 폰트 유틸 함수
+ * @param {*} input 사용방법 ${tm_font('24')} , ${tm_font('24b')}
+ * weight값이 없으면 regular로 출력
+ * @returns 테마에 지정된 스타일 속성값을 문자열로 리턴
+ */
+export const tm_font =
+  (input) =>
+  ({ theme }) => {
+    // 숫자와 마지막 문자를 분리하는 정규식
+    const match = input.match(/^(\d+)([bB]?)$/);
+
+    if (!match) {
+      console.error(
+        `Error: 잘못된 폰트 입력값 '${input}' 입니다. 두 자리 이상의 숫자를 입력해야 합니다.`,
+      );
+      return '';
+    }
+
+    const size = match[1]; // 숫자 부분
+    const weight = match[2] === 'b' || match[2] === 'B' ? 'Bold' : 'Regular'; // weight가 b이면 Bold로 설정
+    const fontKey = `${size}${weight}`; // 최종 fontKey 생성
+
+    const fontStyle = theme.fontTheme[fontKey];
+
+    if (!fontStyle) {
+      console.error(`Error: 테마에 '${fontKey}' 스타일이 없습니다.`);
+      return '';
+    }
+
+    // 개별 속성을 CSS 문자열로 반환
+    return `
+      font-weight: ${fontStyle.fontWeight};
+      font-size: ${fontStyle.fontSize};
+      line-height: ${fontStyle.lineHeight};
+      letter-spacing: ${fontStyle.letterSpacing};
+    `;
+  };
+
+/**
+ * 색상 유틸 함수
+ * @param {*} inputColor 사용방법 ${tm_color('blue300')}, ${tm_color('black')}, ${tm_color('#FFF0D6')}
+ * hex 값으로 작성했을때, 만일 테마에 없는 속성값이면 해당 hex 값을 그대로 반환
+ * @returns 테마에 지정된 스타일 속성값으로 리턴
+ */
+export const tm_color =
+  (inputColor) =>
+  ({ theme }) => {
+    // 모든 색상 값을 플랫하게 변환하여 색상 코드와 키를 매핑
+    const flattenColors = Object.entries(theme.colorTheme).reduce(
+      (acc, [key, value]) => {
+        if (typeof value === 'object') {
+          Object.entries(value).forEach(([shade, hex]) => {
+            acc[`${key}${shade}`] = hex; // "blue500" 등 키와 hex 값 매핑
+          });
+        } else {
+          acc[key] = value; // 단일 색상 값 (예: white, black 등)
+        }
+        return acc;
+      },
+      {},
+    );
+
+    // 테마에 일치하는 색상 코드가 있으면 반환, 없으면 그대로 반환
+    return flattenColors[inputColor.toLowerCase()] || inputColor;
+  };


### PR DESCRIPTION
### 이슈 번호 

close #138 

### 변경 사항 요약 

기존에 복잡했던 테마 함수를 손쉽게 쓸 수 있습니다!

- 기존
`${({theme} => theme.colorTheme.blue[200])} `
- 유틸 함수 사용 시
`${tm_color('blue200')}`

- 기존
`${({theme}) => theme.fontTheme['20Regular']}`
- 유틸 함수 사용시
`${tm_font('20')}`

### 설명
1. 폰트 함수(`tm_font`)
- 폰트는 폰트사이즈 입력하고 뒤에 아무것도 입력 안할경우 디폴트 값인 Regular로 자동적용 => ex : `${tm_font('20')}`
- 폰트사이즈 입력하고 b 입력 시 Bold => ex : `${tm_font('20b')}`
- 만약 테마에 없는 값일 경우 콘솔 에러 메시지 띄워줌
2. 컬러 함수(`tm_color`)
- 컬러는 정의된 네임과 숫자를 입력하면 적용됨 `${tm_color('blue300')}`
- 컬러 값이 아니더라도 hex로 입력해도 가능 `${tm_color('#9be282')}`
- 테마에 있는 고정값도 사용 가능 `${tm_color('white')}`
- 없는 색상도 괜찮아요! hex 코드가 그대로 적용! `color: ${tm_color('#374b5e')}` => `color: #374b5e` 로 적용됨


### 테스트 결과 
![스크린샷 2024-10-30 오전 5 52 40](https://github.com/user-attachments/assets/820a60ac-f12c-4c63-8e5e-e9a55922d5de)
- 에러코드가 뜬 부분은 `${tm_font('2')}`, `${tm_font('100')}`
