### PR TITLE
#136 Outlined 컴포넌트의 스타일컴포넌트 변수사용시 $ 누락문제 수정

### DIFF
--- a/src/components/Outlined/Outlined.styles.js
+++ b/src/components/Outlined/Outlined.styles.js
@@ -48,12 +48,12 @@ const sizeStyles = {
 };
 
 export const StOutlined = styled.button`
-  ${({ size }) => sizeStyles[size]}
+  ${({ $size }) => sizeStyles[$size]}
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex-direction: ${({ iconPosition }) =>
-    iconPosition === 'right' ? 'row-reverse' : 'row'};
+  flex-direction: ${({ $iconPosition }) =>
+    $iconPosition === 'right' ? 'row-reverse' : 'row'};
 
   ${OutlinedStyles}
 `;


### PR DESCRIPTION
### 이슈 번호 

close #136 

### 버그 내용

옵셔널 속성인 `iconPosition` 을 사용하지 않았는데 관련하여 아래와 같은 에러 문구가 발생함
```
hook.js:608 Warning: React does not recognize the `iconPosition` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `iconposition` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack
```
---
### 버그 발생 이유
- 정확한 스타일드컴포넌트의 규칙에 대해 미숙하여 생긴 버그입니다.

**아래는 이번 버그 발생에 대한 내용을 글로 정리하였습니다.**

동기적인 스타일링을 위해 스타일드컴포넌트에 변수를 전달하고 그 변수명을 그대로 받아서 사용하였는데,
스타일드컴포넌트에서 사용할때 변수명에 $를 붙이지 않고 그대로 사용하여 생긴 버그입니다.

해당 버그에 대해 알아보니
스타일드 컴포넌트가 받은 prop에 대해서 $를 붙이면 자체적으로 CSS 처리에만 사용되고, 
DOM에는 전달하지 않도록 라이브러리가 특별처리를 해준다고 합니다.
하지만 변수명에 $를 붙이지 않고 그냥 사용하게 되면 DOM 엘리먼트에 전달하게 되고,
스타일 컴포넌트도 컴포넌트이기 떄문에 하위 컴포넌트로 해당 속성이 전파될 수 있다고 합니다.

즉, 버튼 태그를 예로 한번 들어보자면
button 태그에 일반적으로 사용되는 속성으로는 아래 예시와 같이 type , className, id, disabled 등이 있을겁니다.
```
<button type="button" className="btn" disabled></button>
```
이 속성들은 실제로 HTML에서 쓸수있는 약속된 표준 속성이죠.
그런데 위와 같이 스타일컴포넌트에서 사용하기 위한 iconPosition같은 prop이 의도치 않은 
DOM 전파로인해 button에 속성으로 들어오게 된다는겁니다.
그로 인해서 브라우저는 이 속성을 처리하지 못하고 리액트가 경고를 발생시키는데, 그게 이번 버그같은 현상입니다.

---



### 버그 수정 사항

![image](https://github.com/user-attachments/assets/dc7043f9-e4c7-459b-bcaa-793b4238cc23)
- 스타일드 컴포넌트 내부에서 변수사용하면서 앞에 $ 가 누락된 부분 추가하였습니다.
