### PR TITLE
#163 메세지 작성하기 컨테이너 작업 

### DIFF
--- a/src/components/InputFile/InputFile.jsx
+++ b/src/components/InputFile/InputFile.jsx
@@ -9,9 +9,12 @@ import {
 } from './InputFile.styles';
 import { getProfileImg } from '../../service/api';
 import Profile from '../Profile/Profile';
+import useDeviceType from '../../hooks/useDeviceType';
 
 function InputFile({ img, onClick }) {
   const [profileImgList, setProfileImgList] = useState([]);
+  const deviceType = useDeviceType(); //devicehook 사용
+  const isMobile = deviceType === 'mobile';
 
   useEffect(() => {
     const handleProfileImgLoad = async () => {
@@ -29,7 +32,7 @@ function InputFile({ img, onClick }) {
 
   return (
     <StyledInputFile>
-      <Profile size="m" imageURL={img} />
+      <Profile size="l" imageURL={img} />
 
       <StyledImgSelectorContainer>
         <p>프로필 이미지를 선택해주세요!</p>
@@ -39,7 +42,7 @@ function InputFile({ img, onClick }) {
             <Profile
               onClick={onClick}
               key={index}
-              size="s"
+              size={isMobile ? 's' : 'm'}
               imageURL={imgItem}></Profile>
           ))}
         </StyledImgArea>

--- a/src/components/InputFile/InputFile.styles.js
+++ b/src/components/InputFile/InputFile.styles.js
@@ -24,5 +24,11 @@ const StyledImgArea = styled.div`
   img {
     cursor: pointer;
   }
+
+  /* 모바일 */
+  @media screen and (max-width: 767px) {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+  }
 `;
 export { StyledInputFile, StyledImgSelectorContainer, StyledImgArea };

--- a/src/components/InputFile/InputFile.styles.js
+++ b/src/components/InputFile/InputFile.styles.js
@@ -10,7 +10,7 @@ const StyledImgSelectorContainer = styled.div`
   flex-direction: column;
   margin-left: 2.6rem;
 
-  > p {
+  p {
     ${({ theme }) => theme.fontTheme['16Regular']}
     color: ${({ theme }) => theme.colorTheme.grayscale[500]}
   }

--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -6,7 +6,7 @@ import DEFAULT_IMAGE from '../../assets/default_profile.svg';
 
 Profile.propTypes = {
   imageURL: PropTypes.string,
-  size: PropTypes.oneOf(['s', 'm']),
+  size: PropTypes.oneOf(['s', 'm', 'l']),
   onClick: PropTypes.func,
 };
 

--- a/src/components/Profile/Profile.styles.js
+++ b/src/components/Profile/Profile.styles.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 const size = {
-  s: '5.6rem',
-  m: '8rem',
+  s: '4rem',
+  m: '5.6rem',
+  l: '8rem',
 };
 
 export const ProfileArea = styled.div`

--- a/src/components/TextField/CommonInput.styles.js
+++ b/src/components/TextField/CommonInput.styles.js
@@ -40,8 +40,6 @@ export const StyledInput = css`
 
 export const StyledErrMessage = css`
   color: ${({ theme }) => theme.colorTheme.error};
-  opacity: ${({ $error }) => ($error ? 1 : 0)};
-  transition: opacity 0.3s ease;
 
   ${({ theme }) => theme.fontTheme['12Regular']};
 `;

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -90,6 +90,7 @@ function Dropdown({
 
   return (
     <>
+      {/* icon 버튼인지 보통의 Dropdown인지 구분 */}
       {isIcon ? (
         <IconBtn
           src={Share}

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -81,9 +81,7 @@ function Dropdown({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
-  const $deviceType = useDeviceType(); //devicehook 사용
-
-  console.log(hasOptions.selectedOption);
+  const deviceType = useDeviceType(); //devicehook 사용
 
   const handleSelect = (option) => {
     hasOptions.onSelect(option); // 선택한 option을 부모로 전달
@@ -121,7 +119,7 @@ function Dropdown({
           onClick={() => setIsOpen(!isOpen)}
           $error={hasError.$error}
           disabled={disabled}
-          deviceType={$deviceType}>
+          $deviceType={deviceType}>
           {/* Item 중 가장 처음 값 세팅 */}
           {hasOptions.selectedOption.label
             ? hasOptions.selectedOption.label

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -1,4 +1,28 @@
 // 드롭다운
+/**
+ * 메시지 카드 단일 컴포넌트
+ * MessageCard 컴포넌트
+ *
+ * 이 컴포넌트는 메시지 카드를 렌더링하는 컴포넌트로,
+ * 'card', 'modal', 'edit' 타입에 따라 각각 다른 UI와 이벤트 동작을 제공합니다.
+ *
+ * @component
+ * @param {string} type - 메시지 카드의 타입 (예: 'card', 'modal', 'edit') *필수값
+ * @param {Object} messageData - 메시지 데이터 객체 *필수값
+ * @param {string} messageData.content - 메시지 내용 (HTML 형식으로 삽입 가능)
+ * @param {string} messageData.createdAt - 메시지 생성일
+ * @param {Object} onEvent - 이벤트 핸들러 객체
+ * @param {Function} onEvent.modal - 모달을 여는 이벤트 핸들러 (카드 타입일 때 동작)
+ * @param {Function} onEvent.close - 모달을 닫는 이벤트 핸들러 (모달 타입일 때 동작)
+ *
+ * @example
+ * <MessageCard
+ *    type="modal"
+ *    messageData={{ content: "<p>Hello World</p>", createdAt: "2024-10-30T01:51:19.832098Z" }}
+ *    onEvent={{ modal: handleModalOpen, close: handleClose }}
+ * />
+ * */
+
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 
@@ -15,20 +39,43 @@ import ArrowTop from '../../assets/icon-arrow_top.svg';
 import Share from '../../assets/icon-share-24.svg';
 import useDeviceType from '../../hooks/useDeviceType';
 
+Dropdown.propTypes = {
+  hasOptions: PropTypes.shape({
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.string,
+      }),
+    ),
+    selectedOption: PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    }),
+    onSelect: PropTypes.func,
+  }),
+  hasError: PropTypes.shape({
+    $error: PropTypes.bool,
+    errMessage: PropTypes.string,
+  }),
+  disabled: PropTypes.bool,
+  isIcon: PropTypes.bool,
+};
+
 function Dropdown({
-  options, //option 종류
-  selectedOption, //선택된 option
-  onSelect, //option을 선택하기 위한 event 함수
+  hasOptions,
+  hasError = {
+    $error: false,
+    errMessage: '옵션을 선택해주세요.',
+  },
   disabled,
-  $error,
-  errMessage = '옵션을 선택해주세요.',
   isIcon,
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const deviceType = useDeviceType(); //devicehook 사용
+  const $deviceType = useDeviceType(); //devicehook 사용
+  console.log(hasOptions.selectedOption);
 
   const handleSelect = (option) => {
-    onSelect(option);
+    hasOptions.onSelect(option);
     setIsOpen(false);
   };
 
@@ -39,26 +86,33 @@ function Dropdown({
           src={Share}
           alt="icon"
           onClick={() => setIsOpen(!isOpen)}
-          error={$error}
+          $error={hasError.$error}
           disabled={disabled}
         />
       ) : (
         <DropdownBtn
+          type="button"
           onClick={() => setIsOpen(!isOpen)}
-          error={$error}
+          $error={hasError.$error}
           disabled={disabled}
-          deviceType={deviceType}>
+          deviceType={$deviceType}>
           {/* Item 중 가장 처음 값 세팅 */}
-          {selectedOption ? selectedOption.value : options[0].value}
+          {hasOptions.selectedOption.label
+            ? hasOptions.selectedOption.label
+            : hasOptions.selectedOption.value || hasOptions.options[0].label}
           <ArrowImg src={!isOpen ? ArrowDown : ArrowTop} alt="arrow" />
         </DropdownBtn>
       )}
 
-      <DropdownErrMessage error={$error}>{errMessage}</DropdownErrMessage>
+      {hasError.$error && (
+        <DropdownErrMessage error={hasError.$error}>
+          {hasError.errMessage}
+        </DropdownErrMessage>
+      )}
 
       {isOpen && (
         <DropdownList isIcon={isIcon}>
-          {options.map((option, index) => (
+          {hasOptions.options.map((option, index) => (
             <DropdownItem
               key={index}
               onClick={() => handleSelect(option)}
@@ -71,23 +125,5 @@ function Dropdown({
     </>
   );
 }
-
-Dropdown.propTypes = {
-  options: PropTypes.arrayOf(
-    PropTypes.shape({
-      value: PropTypes.string,
-      label: PropTypes.string,
-    }),
-  ),
-  selectedOption: PropTypes.shape({
-    value: PropTypes.string,
-    label: PropTypes.string,
-  }),
-  onSelect: PropTypes.func,
-  disabled: PropTypes.bool,
-  $error: PropTypes.bool,
-  errMessage: PropTypes.string,
-  isIcon: PropTypes.bool,
-};
 
 export default Dropdown;

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -1,27 +1,36 @@
-// 드롭다운
 /**
- * 메시지 카드 단일 컴포넌트
- * MessageCard 컴포넌트
+ * 드롭다운 단일 컴포넌트
+ * Dropdown 컴포넌트
  *
- * 이 컴포넌트는 메시지 카드를 렌더링하는 컴포넌트로,
- * 'card', 'modal', 'edit' 타입에 따라 각각 다른 UI와 이벤트 동작을 제공합니다.
+ * 이 컴포넌트는 드롭다운 UI를 렌더링하며, 옵션 선택 및 선택한 옵션 표시, 에러 메시지 표시 등의 기능을 제공합니다.
+ * 기본 아이콘 표시 여부, 선택 옵션 및 에러 상태에 따라 UI와 이벤트 동작이 다르게 나타납니다.
  *
  * @component
- * @param {string} type - 메시지 카드의 타입 (예: 'card', 'modal', 'edit') *필수값
- * @param {Object} messageData - 메시지 데이터 객체 *필수값
- * @param {string} messageData.content - 메시지 내용 (HTML 형식으로 삽입 가능)
- * @param {string} messageData.createdAt - 메시지 생성일
- * @param {Object} onEvent - 이벤트 핸들러 객체
- * @param {Function} onEvent.modal - 모달을 여는 이벤트 핸들러 (카드 타입일 때 동작)
- * @param {Function} onEvent.close - 모달을 닫는 이벤트 핸들러 (모달 타입일 때 동작)
+ * @param {Object} hasOptions - 드롭다운 옵션 데이터 *필수값
+ * @param {Array} hasOptions.options - 드롭다운 옵션 배열. 각 옵션은 value와 label 속성을 가집니다.
+ * @param {Object} hasOptions.selectedOption - 현재 선택된 옵션 객체 (예: { value: '1', label: 'Option 1' })
+ * @param {Function} hasOptions.onSelect - 옵션 선택 시 호출되는 이벤트 핸들러
+ * @param {Object} hasError - 에러 상태 및 메시지
+ * @param {boolean} hasError.$error - 에러 여부를 나타내는 불리언 값
+ * @param {string} hasError.errMessage - 에러 메시지 (에러 상태일 때 표시됨)
+ * @param {boolean} disabled - 드롭다운 비활성화 여부
+ * @param {boolean} isIcon - 아이콘 모드 여부 (기본 버튼 대신 아이콘 버튼이 표시됨)
  *
  * @example
- * <MessageCard
- *    type="modal"
- *    messageData={{ content: "<p>Hello World</p>", createdAt: "2024-10-30T01:51:19.832098Z" }}
- *    onEvent={{ modal: handleModalOpen, close: handleClose }}
+ * <Dropdown
+ *    hasOptions={{
+ *       options: [
+ *         { value: '1', label: 'Option 1' },
+ *         { value: '2', label: 'Option 2' }
+ *       ],
+ *       selectedOption: { value: '1', label: 'Option 1' },
+ *       onSelect: handleSelect
+ *    }}
+ *    hasError={{ $error: true, errMessage: "옵션을 선택해주세요." }}
+ *    disabled={false}
+ *    isIcon={true}
  * />
- * */
+ */
 
 import PropTypes from 'prop-types';
 import { useState } from 'react';
@@ -52,7 +61,7 @@ Dropdown.propTypes = {
       label: PropTypes.string,
     }),
     onSelect: PropTypes.func,
-  }),
+  }).isRequired,
   hasError: PropTypes.shape({
     $error: PropTypes.bool,
     errMessage: PropTypes.string,

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -33,7 +33,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import {
   DropdownBtn,
@@ -80,16 +80,32 @@ function Dropdown({
   isIcon,
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
   const $deviceType = useDeviceType(); //devicehook 사용
+
   console.log(hasOptions.selectedOption);
 
   const handleSelect = (option) => {
-    hasOptions.onSelect(option);
+    hasOptions.onSelect(option); // 선택한 option을 부모로 전달
     setIsOpen(false);
   };
 
+  //dropdown 외에 외부를 클릭했을 때 닫히도록 하는 useEffect
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
   return (
-    <>
+    <div ref={dropdownRef}>
       {/* icon 버튼인지 보통의 Dropdown인지 구분 */}
       {isIcon ? (
         <IconBtn
@@ -132,7 +148,7 @@ function Dropdown({
           ))}
         </DropdownList>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/components/TextField/Dropdown.styles.js
+++ b/src/components/TextField/Dropdown.styles.js
@@ -11,6 +11,7 @@ export const DropdownBtn = styled.button`
   width: ${({ $deviceType }) => ($deviceType === 'mobile' ? '100%' : '32rem')};
   padding: 1.2rem 1.6rem;
   ${StyledInput};
+  cursor: pointer;
 `;
 
 export const IconBtn = styled.img`
@@ -20,6 +21,7 @@ export const IconBtn = styled.img`
 
   padding: 0.6rem 1.6rem;
   ${StyledInput};
+  cursor: pointer;
 `;
 
 export const ArrowImg = styled.img`
@@ -41,14 +43,16 @@ export const DropdownList = styled.ul`
 
   background-color: ${tm_color('white')};
   ${tm_shadow('shadow0_2_008')}
+
+  cursor: pointer;
 `;
 
 export const DropdownItem = styled.li`
   padding: 1.2rem 1.6rem;
-
   width: ${({ isIcon }) => (isIcon ? '13.8rem' : '31.6rem')};
 
   ${tm_font('16')}
+  cursor: pointer;
 
   &:hover {
     background-color: ${tm_color('grayscale100')};

--- a/src/components/TextField/Dropdown.styles.js
+++ b/src/components/TextField/Dropdown.styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { StyledInput, StyledErrMessage } from './CommonInput.styles';
+import { tm_color, tm_font, tm_shadow } from '../../utils/themeUtils';
 
 export const DropdownBtn = styled.button`
   display: flex;
@@ -29,25 +30,28 @@ export const ArrowImg = styled.img`
 //SECTION - Dropdown을 내렸을 때 나오는 요소들의 css
 
 export const DropdownList = styled.ul`
+  position: absolute;
+  z-index: 3;
+  margin-top: 0.8rem;
   padding: 1rem 0.1rem;
 
   width: ${({ isIcon }) => (isIcon ? '14rem' : '32rem')};
-
   border: 0.1rem solid #ccc;
   border-radius: 0.8rem;
 
-  box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.08);
+  background-color: ${tm_color('white')};
+  ${tm_shadow('shadow0_2_008')}
 `;
 
 export const DropdownItem = styled.li`
   padding: 1.2rem 1.6rem;
 
-  width: ${({ isIcon }) => (isIcon ? '14rem' : '32rem')};
+  width: ${({ isIcon }) => (isIcon ? '13.8rem' : '31.6rem')};
 
-  ${({ theme }) => theme.fontTheme['16Regular']}
+  ${tm_font('16')}
 
   &:hover {
-    background-color: ${({ theme }) => theme.colorTheme.grayscale['100']};
+    background-color: ${tm_color('grayscale100')};
   }
 `;
 

--- a/src/components/TextField/Dropdown.styles.js
+++ b/src/components/TextField/Dropdown.styles.js
@@ -7,8 +7,7 @@ export const DropdownBtn = styled.button`
   justify-content: space-between;
   align-items: center;
 
-  width: ${({ deviceType }) => (deviceType === 'mobile' ? '100%' : '32rem')};
-  margin-bottom: 0.4rem;
+  width: ${({ $deviceType }) => ($deviceType === 'mobile' ? '100%' : '32rem')};
   padding: 1.2rem 1.6rem;
   ${StyledInput};
 `;

--- a/src/components/TextField/Input.jsx
+++ b/src/components/TextField/Input.jsx
@@ -35,8 +35,10 @@ function Input({
   return (
     <InputWrapper>
       <InputBox
+        name={onEvent.name} // onEvent의 name 전달
+        value={onEvent.value} // onEvent의 value 전달
+        onChange={onEvent.onChange} // onEvent의 onChange 전달
         $error={hasError.$error}
-        onEvent={onEvent}
         disabled={disabled}
         placeholder={placeholder}
         onBlur={onBlur}

--- a/src/components/TextField/Input.jsx
+++ b/src/components/TextField/Input.jsx
@@ -1,6 +1,6 @@
 /**
  * 단일 Input 컴포넌트
- * 
+ *
  * 이 컴포넌트는 텍스트 입력을 위한 기본 `Input` UI를 렌더링하며, 사용자가 입력한 값을 실시간으로 업데이트하거나
  * 에러 메시지를 표시할 수 있습니다. 컴포넌트가 비활성화 상태일 때와 에러 상태일 때 UI와 이벤트 동작이 다르게 나타납니다.
  *
@@ -15,7 +15,7 @@
  * @param {boolean} disabled - Input 비활성화 여부
  * @param {string} placeholder - Input의 기본 placeholder 텍스트
  * @param {Function} onBlur - Input이 blur될 때 호출되는 이벤트 핸들러
- * 
+ *
  * @example
  * <Input
  *    onEvent={{
@@ -29,7 +29,6 @@
  *    onBlur={handleBlur}
  * />
  */
-
 
 import PropTypes from 'prop-types';
 

--- a/src/components/TextField/Input.jsx
+++ b/src/components/TextField/Input.jsx
@@ -32,11 +32,6 @@ function Input({
   placeholder,
   onBlur,
 }) {
-  console.log(
-    !hasError.errMessage || hasError.errMessage.length === 0
-      ? '에러 메세지가 없습니다.'
-      : hasError.errMessage,
-  );
   return (
     <InputWrapper>
       <InputBox

--- a/src/components/TextField/Input.jsx
+++ b/src/components/TextField/Input.jsx
@@ -2,42 +2,57 @@ import PropTypes from 'prop-types';
 
 import { InputWrapper, InputBox, InputErrMessage } from './Input.styles';
 
-function Input({
-  $error,
-  errMessage = '값을 입력해 주세요.',
-  disabled,
-  name,
-  value,
-  onChange,
-  placeholder,
-  onBlur,
-}) {
-  return (
-    <InputWrapper>
-      <InputBox
-        error={$error}
-        disabled={disabled}
-        name={name}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        onBlur={onBlur}
-      />
-      <InputErrMessage error={$error}>{errMessage}</InputErrMessage>
-    </InputWrapper>
-  );
-}
-
 // PropTypes를 정의하여 각 prop의 타입을 명시
 Input.propTypes = {
-  name: PropTypes.string.isRequired,
-  value: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-  $error: PropTypes.bool,
+  onEvent: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+  }).isRequired,
+  hasError: PropTypes.shape({
+    $error: PropTypes.bool,
+    errMessage: PropTypes.string,
+  }),
   disabled: PropTypes.bool,
-  errMessage: PropTypes.string,
   placeholder: PropTypes.string,
   onBlur: PropTypes.func,
 };
+
+function Input({
+  onEvent = {
+    name: '',
+    value: '',
+    onChange: () => {},
+  },
+  hasError = {
+    $error: false,
+    errMessage: '값을 입력해주세요.',
+  },
+  disabled,
+  placeholder,
+  onBlur,
+}) {
+  console.log(
+    !hasError.errMessage || hasError.errMessage.length === 0
+      ? '에러 메세지가 없습니다.'
+      : hasError.errMessage,
+  );
+  return (
+    <InputWrapper>
+      <InputBox
+        $error={hasError.$error}
+        onEvent={onEvent}
+        disabled={disabled}
+        placeholder={placeholder}
+        onBlur={onBlur}
+      />
+      {hasError.$error && (
+        <InputErrMessage error={hasError.$error}>
+          {hasError.errMessage}
+        </InputErrMessage>
+      )}
+    </InputWrapper>
+  );
+}
 
 export default Input;

--- a/src/components/TextField/Input.jsx
+++ b/src/components/TextField/Input.jsx
@@ -1,3 +1,36 @@
+/**
+ * 단일 Input 컴포넌트
+ * 
+ * 이 컴포넌트는 텍스트 입력을 위한 기본 `Input` UI를 렌더링하며, 사용자가 입력한 값을 실시간으로 업데이트하거나
+ * 에러 메시지를 표시할 수 있습니다. 컴포넌트가 비활성화 상태일 때와 에러 상태일 때 UI와 이벤트 동작이 다르게 나타납니다.
+ *
+ * @component
+ * @param {Object} onEvent - Input에 전달되는 이벤트 핸들러 및 상태값 객체 *필수값
+ * @param {string} onEvent.name - Input의 이름 (각 input의 고유 식별자)
+ * @param {string} onEvent.value - Input의 값 (상태로 관리)
+ * @param {Function} onEvent.onChange - Input 값이 변경될 때 호출되는 함수
+ * @param {Object} hasError - 에러 상태 및 메시지 객체
+ * @param {boolean} hasError.$error - 에러 여부를 나타내는 불리언 값
+ * @param {string} hasError.errMessage - 에러 메시지 (에러 상태일 때 표시됨)
+ * @param {boolean} disabled - Input 비활성화 여부
+ * @param {string} placeholder - Input의 기본 placeholder 텍스트
+ * @param {Function} onBlur - Input이 blur될 때 호출되는 이벤트 핸들러
+ * 
+ * @example
+ * <Input
+ *    onEvent={{
+ *       name: 'username',
+ *       value: '사용자 이름',
+ *       onChange: handleChange
+ *    }}
+ *    hasError={{ $error: true, errMessage: "값을 입력해주세요." }}
+ *    disabled={false}
+ *    placeholder="이름을 입력하세요"
+ *    onBlur={handleBlur}
+ * />
+ */
+
+
 import PropTypes from 'prop-types';
 
 import { InputWrapper, InputBox, InputErrMessage } from './Input.styles';

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -19,7 +19,7 @@ function TextField({ onChange }) {
   return (
     <TextFieldContainer>
       <ReactQuill
-        style={{ width: '72rem', height: '22rem' }}
+        style={{ width: '100%', height: '22rem' }}
         modules={modules}
         onChange={onChange}
       />

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
+import { TextFieldContainer } from './TextField.styles';
 
 const toolbarOptions = [
   ['bold', 'italic', 'underline', 'strike'],
@@ -15,13 +16,13 @@ function TextField({ onChange }) {
   };
 
   return (
-    <>
+    <TextFieldContainer>
       <ReactQuill
-        style={{ width: '72rem', height: '26rem' }}
+        style={{ width: '72rem', height: '22rem' }}
         modules={modules}
         onChange={onChange}
       />
-    </>
+    </TextFieldContainer>
   );
 }
 

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -1,7 +1,10 @@
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
 
-import { TextFieldContainer } from './TextField.styles';
+const TextFieldContainer = styled.div`
+  height: 26rem;
+`;
 
 const toolbarOptions = [
   ['bold', 'italic', 'underline', 'strike'],

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
+
 import { TextFieldContainer } from './TextField.styles';
 
 const toolbarOptions = [

--- a/src/components/TextField/TextField.styles.js
+++ b/src/components/TextField/TextField.styles.js
@@ -1,5 +1,0 @@
-import styled from 'styled-components';
-
-export const TextFieldContainer = styled.div`
-  height: 26rem;
-`;

--- a/src/components/TextField/TextField.styles.js
+++ b/src/components/TextField/TextField.styles.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const TextFieldContainer = styled.div`
+  height: 26rem;
+`;

--- a/src/pages/MessagesAdd/MessagesAddPage.jsx
+++ b/src/pages/MessagesAdd/MessagesAddPage.jsx
@@ -139,16 +139,18 @@ function MessagesAddPage() {
       <form onSubmit={handlePostSubmit}>
         <StyledLabel>Form.</StyledLabel>
         <Input
-          // NOTE 콘솔에러 : 조건부로 전달하여 false일 때 DOM에 전달되지 않도록
-          error={error || undefined}
-          errMessage={errMessage}
-          name="sender"
-          value={value}
-          onChange={onChange}
+          hasError={{
+            $error: error || false,
+            errMessage: errMessage || '값을 입력해주세요.',
+          }}
+          onEvent={{
+            name: 'sender',
+            value: value,
+            onChange: onChange,
+          }}
           placeholder="이름을 입력해 주세요."
           onBlur={onBlur}
         />
-
         <StyledLabel>프로필 이미지</StyledLabel>
         <InputFile
           name="profileImageURL"
@@ -158,16 +160,17 @@ function MessagesAddPage() {
 
         <StyledLabel>상대와의 관계</StyledLabel>
         <Dropdown
-          options={relationshipData}
-          selectedOption={{
-            value: values.relationship,
+          hasOptions={{
+            options: relationshipData,
+            selectedOption: {
+              value: values.relationship,
+            },
+            onSelect: (option) =>
+              setValues((prevValues) => ({
+                ...prevValues,
+                relationship: option.value,
+              })),
           }}
-          onSelect={(option) =>
-            setValues((prevValues) => ({
-              ...prevValues,
-              relationship: option.value,
-            }))
-          }
         />
 
         <StyledLabel>내용을 입력해 주세요.</StyledLabel>
@@ -175,16 +178,17 @@ function MessagesAddPage() {
 
         <StyledLabel>폰트 선택</StyledLabel>
         <Dropdown
-          options={fontData}
-          selectedOption={{
-            value: values.font,
+          hasOptions={{
+            options: fontData,
+            selectedOption: {
+              value: values.font,
+            },
+            onSelect: (option) =>
+              setValues((prevValues) => ({
+                ...prevValues,
+                font: option.value,
+              })),
           }}
-          onSelect={(option) =>
-            setValues((prevValues) => ({
-              ...prevValues,
-              font: option.value,
-            }))
-          }
         />
 
         {/* 이름, 내용을 입력하지 않으면 disabled */}

--- a/src/pages/MessagesAdd/MessagesAddPage.styles.js
+++ b/src/pages/MessagesAdd/MessagesAddPage.styles.js
@@ -5,9 +5,15 @@ import { tm_color, tm_font } from '../../utils/themeUtils';
 const StyledMessagesAddPage = styled.div`
   width: 72rem; // NOTE 해당 코드는 임시로 잡아둔 값으로 전체적으로 컴포넌트 조합할 때 수정하겠습니다.
   margin: 0 auto;
+  margin-bottom: 8rem; // NOTE 해당 코드는 임시로 잡아둔 값으로 전체적으로 컴포넌트 조합할 때 수정하겠습니다.
 
   button[type='submit'] {
     margin-top: 6.2rem;
+  }
+
+  /* 모바일 */
+  @media screen and (max-width: 767px) {
+    width: 32rem;
   }
 `;
 

--- a/src/pages/MessagesAdd/MessagesAddPage.styles.js
+++ b/src/pages/MessagesAdd/MessagesAddPage.styles.js
@@ -5,7 +5,7 @@ import { tm_color, tm_font } from '../../utils/themeUtils';
 const StyledMessagesAddPage = styled.div`
   width: 72rem; // NOTE 해당 코드는 임시로 잡아둔 값으로 전체적으로 컴포넌트 조합할 때 수정하겠습니다.
   margin: 0 auto;
-  margin-bottom: 8rem; // NOTE 해당 코드는 임시로 잡아둔 값으로 전체적으로 컴포넌트 조합할 때 수정하겠습니다.
+  margin-bottom: 20rem; // NOTE 해당 코드는 임시로 잡아둔 값으로 전체적으로 컴포넌트 조합할 때 수정하겠습니다.
 
   button[type='submit'] {
     margin-top: 6.2rem;


### PR DESCRIPTION
### 이슈 번호

close #163

### 변경 사항 요약

1. dropdown, Input 부분의 props를 객체화하여 코드의 가독성을 높이고자 했습니다. 
-> 코드에 설명 첨가 했습니다 :-) 

- dropdown과 관련하여 @hwiiron 께서 요청해주신 작업들 모두 완료했습니다! 
- [x] component margin 정리 
- [x] drodown -> position, cursor, type
- [x] error visibility 관련 부분
- [x] textField height 부분 
- 또 추가적으로 dropdown 외부 클릭시 dropdown이 접히도록 개발해두었습니다. 

2. 메세지 추가하기 컨테이너 작업을 반응형으로 만들어 두었습니다 
@Hogn-hyeonbin 나중에 메세지 수정하기 작업하실 때 `MessagesAddPage`참고하셔서 그대로 가져다 쓰시고 안에 함수만 수정하는 함수로 가져다가 쓰시면 될 것 같습니다 👍 


### 테스트 결과

베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.

`PC`
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/9f334ea5-a3b4-4ca6-b5b5-e68c956d12a4">


`태블릿`
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/ca6efde4-4a1e-4c81-b227-686101e29556">


`모바일`
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/70967e23-15f7-4d43-a1ab-c621d977bb67">

