### PR TITLE
#191 애로우버튼 블러,투명도 적용

### DIFF
--- a/src/components/ArrowButton/ArrowButton.styles.js
+++ b/src/components/ArrowButton/ArrowButton.styles.js
@@ -1,5 +1,7 @@
 import styled, { css } from 'styled-components';
 
+import { blur } from '../../styles/blurStyles';
+
 export const ArrowArea = styled.button`
   width: 4rem;
   height: 4rem;
@@ -10,12 +12,26 @@ export const ArrowArea = styled.button`
   align-items: center;
   justify-content: center;
   transition: all 0.3s;
+  position: relative;
 
   &:hover {
     transform: scale(1.02);
   }
   &:active {
     transform: scale(0.97);
+  }
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 50%;
+    background-color: white;
+    filter: ${blur};
+    opacity: 0.9;
+    z-index: -1;
   }
 `;
 


### PR DESCRIPTION
### 이슈 번호

close #191

### 변경 사항 요약

리스트페이지 카드이동하는 화살표버튼 figma에 맞게 투명도와 블러적용
- 블러는 변수설정해논것 사용하였음

### 테스트 결과

![image](https://github.com/user-attachments/assets/5719c424-6828-4ddd-b2ab-04a0b9a8703e)

사진은 테스트를 위해 눈에 잘보이게 black으로 찍었고, 실제는 white로 맞게 잘 적용되었습니다.