### PR TITLE
#196 수정하기 페이지 기능 구현

### DIFF
--- a/src/components/MessagesCardList/MessageCardList.jsx
+++ b/src/components/MessagesCardList/MessageCardList.jsx
@@ -47,8 +47,8 @@ MessageCardList.propTypes = {
 };
 
 // STUB - Edit 버튼을 클릭했을 때 이벤트 함수 입니다.
-const handleEditClick = (id, event) => {
-  event.stopPropagation();
+const handleEditClick = (id, messageData, navigate) => {
+  navigate(`/list/${id}/message`, { state: { messageData } });
   // TODO - 원활한 테스팅을 위해 추가했습니다. 기능 작업이 완료되면 삭제해주세요
   console.log(`클릭 카드 ID : ${id}, [수정 페이지로 이동 합니다]`);
 };
@@ -115,7 +115,10 @@ function MessageCardList({ type, messageData = [], onEvent, children }) {
             onEvent={{
               modal: () => onEvent.modal(item.id),
               buttonDelete: (event) => handleDeleteClick(item.id, event),
-              buttonEdit: (event) => handleEditClick(item.id, event),
+              buttonEdit: (event) => {
+                event.stopPropagation();
+                handleEditClick(item.id, item, navigate);
+              },
             }}
           />
         ))}

--- a/src/components/MessagesCardList/MessageCardList.jsx
+++ b/src/components/MessagesCardList/MessageCardList.jsx
@@ -25,8 +25,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import {
@@ -44,13 +43,6 @@ MessageCardList.propTypes = {
   messageData: PropTypes.array.isRequired,
   onEvent: PropTypes.object,
   children: PropTypes.any,
-};
-
-// STUB - Edit 버튼을 클릭했을 때 이벤트 함수 입니다.
-const handleEditClick = (id, messageData, navigate) => {
-  navigate(`/list/${id}/message`, { state: { messageData } });
-  // TODO - 원활한 테스팅을 위해 추가했습니다. 기능 작업이 완료되면 삭제해주세요
-  console.log(`클릭 카드 ID : ${id}, [수정 페이지로 이동 합니다]`);
 };
 
 // STUB - 해당 컴포넌트의 messageData는 배열로 받아옵니다.
@@ -96,6 +88,11 @@ function MessageCardList({ type, messageData = [], onEvent, children }) {
   if (loading) return <p>로딩 중 입니다...</p>;
   if (error) return <p>데이터 삭제에 실패했습니다 🫠</p>;
 
+  // STUB - Edit 버튼을 클릭했을 때 이벤트 함수 입니다.
+  const handleEditClick = (presentId, messageId) => {
+    navigate(`/post/${presentId}/message?id=${messageId}`);
+  };
+
   return (
     <StyledCardListContainer>
       {isEdit === 'edit' && (
@@ -117,7 +114,7 @@ function MessageCardList({ type, messageData = [], onEvent, children }) {
               buttonDelete: (event) => handleDeleteClick(item.id, event),
               buttonEdit: (event) => {
                 event.stopPropagation();
-                handleEditClick(item.id, item, navigate);
+                handleEditClick(presentId, item.id);
               },
             }}
           />

--- a/src/components/TextField/TextEditor.jsx
+++ b/src/components/TextField/TextEditor.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 const KEY = process.env.REACT_APP_TEXT_EDITOR_KEY;
 
-function TextEditor({ onChange }) {
+function TextEditor({ onChange, value }) {
   const editorRef = useRef(null);
 
   // 실시간 변경 감지
@@ -16,6 +16,7 @@ function TextEditor({ onChange }) {
   return (
     <>
       <Editor
+        value={value}
         apiKey={KEY}
         onInit={(_evt, editor) => (editorRef.current = editor)}
         init={{
@@ -54,7 +55,8 @@ function TextEditor({ onChange }) {
 }
 
 TextEditor.propTypes = {
-  onChange: PropTypes.func.isRequired, // onChange prop은 필수
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string,
 };
 
 export default TextEditor;

--- a/src/pages/MessagesAdd/MessagesAddPage.jsx
+++ b/src/pages/MessagesAdd/MessagesAddPage.jsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { StyledLabel, StyledMessagesAddPage } from './MessagesAddPage.styles';
 import Button from '../../components/Button/Button';
 import InputFile from '../../components/InputFile/InputFile';
 import Dropdown from '../../components/TextField/Dropdown';
 import Input from '../../components/TextField/Input';
-import TextField from '../../components/TextField/TextField';
 import useInputValidation from '../../hooks/useInputValidation';
-import { postMessages } from '../../service/api';
+import { getMessages, patchMessages, postMessages } from '../../service/api';
 import TextEditor from '../../components/TextField/TextEditor';
 
 const INITIAL_VALUES = {
@@ -71,25 +70,48 @@ function MessagesAddPage() {
   // post 요청 데이터
   const [values, setValues] = useState(INITIAL_VALUES);
 
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 쿼리 파라미터 추출
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const messageId = queryParams.get('id');
+
   // 보내는 사람 이름
-  const { value, error, errMessage, onChange, onBlur } = useInputValidation();
+  const { error, errMessage, onChange, onBlur } = useInputValidation();
 
   // 보내는 사람 이름, 내용이 입력되지 않았을 경우, 생성하기 버튼 disabled
   const isValidation =
-    !value ||
-    error ||
-    values.content === '' ||
-    values.content === '<p><br></p>';
-  // 조건에 values.content === '<p><br></p>' 추가 이유
-  // 텍스트 에디터에 내용을 입력 후, 내용을 지우면 텍스트 에디터 value가 빈 값이 아닌 <p><br></p>가 남게 되어 이 부분도 조건에 추가
+    values.sender &&
+    !error &&
+    values.content &&
+    values.content !== '<p><br></p>';
 
   useEffect(() => {
     setValues((prevValues) => ({
       ...prevValues,
       recipientId: params.id,
-      sender: value,
+      // sender: value,
     }));
-  }, [params.id, value]);
+  }, [params.id]);
+
+  // [수정] 메시지 데이터 GET 요청하여 values에 저장
+  useEffect(() => {
+    const handleMessageData = async () => {
+      // 쿼리 파라미터에 messageId가 있으면,
+      if (messageId) {
+        // 해당 메시지 데이터 추출하여 values에 저장
+        const messageData = await getMessages(messageId);
+
+        setValues((prevValues) => ({
+          ...prevValues,
+          ...messageData,
+        }));
+      }
+    };
+
+    handleMessageData();
+  }, [messageId]);
 
   // 프로필 이미지 상태 업데이트
   const handleImgClick = (value) => {
@@ -105,31 +127,36 @@ function MessagesAddPage() {
   const handlePostSubmit = async (e) => {
     e.preventDefault();
 
-    // NOTE FormData와의 차이점 - 해당 내용은 배포 전에 삭제하도록 하겠습니다. 이것 때문에 몇시간을 POST 요청을 못한건지...ㅠ
-    // FormData: 파일 업로드와 같은 이진 데이터를 포함할 수 있는 요청 형식입니다. 주로 multipart/form-data로 전송됩니다.
-    // application/json: 단순한 텍스트 데이터로 구성된 요청 형식입니다. 파일이나 이진 데이터를 전송할 수 없습니다.
-
-    // 서버에서 어떤 형식의 데이터를 기대하는지에 따라 이 두 가지 형식 중 하나를 선택해야 합니다.
-    // FormData로 데이터를 보내고 싶다면, 서버가 이를 처리할 수 있도록 설정되어 있어야 합니다.
-    // JSON 형식으로 보내려면, 데이터가 JSON으로 직렬화되어야 하고, 서버가 application/json 형식을 이해해야 합니다.
     const messageData = {
-      // spread 전개 연산자를 활용
       ...values,
-      // team: values.team,
-      // recipientId: values.recipientId,
-      // sender: values.sender,
-      // profileImageURL: values.profileImageURL,
-      // relationship: values.relationship,
-      // content: values.content,
-      // font: values.font,
     };
 
     try {
-      await postMessages(params.id, messageData);
-      nav(`/post/${params.id}`, { replace: true }); // 메시지를 보낸 롤링페이퍼 페이지로 이동
+      setIsLoading(true);
+      if (!messageId) {
+        await postMessages(params.id, messageData);
+      } else {
+        await patchMessages(messageId, messageData);
+      }
+      nav(`/post/${params.id}`); // 메시지를 보낸 롤링페이퍼 페이지로 이동
     } catch (error) {
       console.error('메시지를 생성하는데 오류가 발생 했습니다.:', error);
+    } finally {
+      setIsLoading(false);
     }
+  };
+
+  if (isLoading) return <p>로딩중입니다...🤩</p>;
+
+  const handleSenderChange = (e) => {
+    // useValidation에 이벤트 객체 전달하여 유효성 검사
+    onChange(e);
+
+    // 입력 값 저장
+    setValues((prevValue) => ({
+      ...prevValue,
+      sender: e.target.value,
+    }));
   };
 
   return (
@@ -143,8 +170,9 @@ function MessagesAddPage() {
           }}
           onEvent={{
             name: 'sender',
-            value: value,
-            onChange: onChange,
+            value: values.sender,
+            // onChange: onChange,
+            onChange: handleSenderChange,
           }}
           placeholder="이름을 입력해 주세요."
           onBlur={onBlur}
@@ -173,7 +201,7 @@ function MessagesAddPage() {
 
         <StyledLabel>내용을 입력해 주세요.</StyledLabel>
         {/* <TextField onChange={handleEditorChange} /> */}
-        <TextEditor onChange={handleEditorChange} />
+        <TextEditor onChange={handleEditorChange} value={values.content} />
 
         <StyledLabel>폰트 선택</StyledLabel>
         <Dropdown
@@ -191,8 +219,8 @@ function MessagesAddPage() {
         />
 
         {/* 이름, 내용을 입력하지 않으면 disabled */}
-        <Button size="xl" type="submit" disabled={isValidation}>
-          생성하기
+        <Button size="xl" type="submit" disabled={!isValidation}>
+          {!messageId ? '생성하기' : '수정하기'}
         </Button>
       </form>
     </StyledMessagesAddPage>


### PR DESCRIPTION
### 이슈 번호

close #196 

### 변경 사항 요약

- `/post/롤링페이퍼 id/edit`에서 수정 버튼 클릭하면 해당하는 메시지 수정페이지로 이동하며, 생성 페이지를 재사용합니다
- 메시지의 id인 쿼리 파라미터를 저장하고, 데이터 요청을 하여 해당 메시지 데이터를 받아서 화면에 노출시킵니다.
- 수정하기 버튼을 클릭하면 PATCH 데이터 요청으로 메시지 데이터가 수정되고, 해당 롤링페이퍼로 이동하게 됩니다.
- 로딩 추가하였습니다.

### 테스트 결과

### 수정하기 버튼 클릭 시 이동한 수정 페이지(생성 재사용)입니다.
<img width="704" alt="스크린샷 2024-11-02 01 47 48" src="https://github.com/user-attachments/assets/7e634a77-17ce-4f32-b6f5-00bee9b11b77">
