### PR TITLE
🐛 홈페이지 불러와지지 못하는 버그 잡기

### DIFF
--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -67,4 +67,4 @@ function Homepage() {
   );
 }
 
-export default HomePages;
+export default Homepage;


### PR DESCRIPTION
홈페이지 불러와지지 못하는 버그 잡기

### 이슈 번호

close #228 

### 변경 사항 요약

- 홈페이지를 제대로 불러오지 못해 급히 판 이슈였습니당 !

### 테스트 결과

베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8f9e9019-ef9e-40dd-b4d6-5f389f3bcdca">

