### PR TITLE
#220 관리자 모드 버튼 패스워드로 edit로 이동

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ REACT_APP_BASE_URL=https://rolling-api.vercel.app/11-2
 
 # 텍스트 에디터 Key - Tiny
 REACT_APP_TEXT_EDITOR_KEY=n8pcucxg9bf3qndp18fhjhobhptbqqohtzuixggyjrd74i13
+
+# 관리자 모드 key
+REACT_APP_ADMIN_KEY=rolling

--- a/src/components/CardComponents/CardList/CardList.jsx
+++ b/src/components/CardComponents/CardList/CardList.jsx
@@ -20,6 +20,7 @@ function CardList({ type, messageData = [], onEvent, children }) {
   const navigate = useNavigate();
   const location = useLocation();
   const deviceType = useDeviceType();
+  const nav = useNavigate();
 
   useEffect(() => {
     setMessageDataList(messageData);
@@ -81,8 +82,15 @@ function CardList({ type, messageData = [], onEvent, children }) {
       </Message>
     );
 
+  const onClick = () => {
+    nav('./edit');
+  };
+
+  const presentPage = currentPathSegments[currentPathSegments.length - 1];
+
   return (
     <CardListContainer>
+      {presentPage !== 'edit' && <Button onClick={onClick}>관리자모드</Button>}
       {type === 'edit' && (
         <ButtonArea>
           <Button

--- a/src/pages/MessagesEdit/MessagesEditPage.jsx
+++ b/src/pages/MessagesEdit/MessagesEditPage.jsx
@@ -6,7 +6,8 @@
  * 재사용 불가한 페이지 컴포넌트 입니다.
  */
 
-import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled, css } from 'styled-components';
 
 import { getMessagesList, getRollingItem } from '../../service/api';
@@ -59,10 +60,14 @@ export const StyledInner = styled.div`
   }
 `;
 
+const KEY = process.env.REACT_APP_ADMIN_KEY;
+
 function MessagesListPage() {
   const currentURL = useLocation();
   const presentPath = currentURL.pathname.split('/');
   const currentId = presentPath[presentPath.length - 2];
+
+  const nav = useNavigate();
 
   // STUB - 메시지 리스트 요청
   const {
@@ -84,6 +89,17 @@ function MessagesListPage() {
       backgroundImageURL: res.backgroundImageURL,
     }),
   );
+
+  useEffect(() => {
+    const AdminCheck = prompt(
+      '관리자만 접근할 수 있습니다. 비밀번호를 입력해 주세요.',
+    );
+
+    if (AdminCheck !== KEY) {
+      alert('비밀번호가 틀렸습니다.');
+      nav(-1);
+    }
+  }, []);
 
   // TODO - 추후 로딩과 에러 페이지 별도 작업
   if (messageLoading || backgroundLoading) return <p>로딩 중 입니다</p>;


### PR DESCRIPTION
### 이슈 번호

close #220 

### 변경 사항 요약

메시지 리스트 페이지에서 관리자모드 버튼 클릭 시 검증 후, 수정페이지로 이동하는 로직 추가하였습니다.
비밀번호의 경우 제 임의대로 정한 것이므로, 필요 시 수정하셔도 됩니다.
비밀번호 확인은 `.env` 파일에서 직접 확인 부탁드립니다!

### 테스트 결과
<img width="1295" alt="스크린샷 2024-11-03 21 06 23" src="https://github.com/user-attachments/assets/b515cc7d-31fc-4ee8-ac69-41b037aa23f7">
