### PR TITLE
#246 ✨ 버튼 로딩스피너 추가

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { StButton } from './Button.styles';
+import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 Button.propTypes = {
   size: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
@@ -13,6 +14,7 @@ Button.propTypes = {
   children: PropTypes.node.isRequired,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
   to: PropTypes.string,
+  loading: PropTypes.bool,
 };
 
 function Button({
@@ -23,6 +25,7 @@ function Button({
   disabled = false,
   type = 'button',
   to,
+  loading = false,
 }) {
   const TAG = to ? Link : 'button';
   return (
@@ -34,7 +37,7 @@ function Button({
       as={TAG}
       {...(TAG === Link && { to })}
       type={TAG === 'button' ? type : undefined}>
-      {children || '텍스트'}
+      {loading ? <LoadingSpinner /> : children || '텍스트'}
     </StButton>
   );
 }

--- a/src/components/LoadingSpinner/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './LoadingSpinner.module.css';
+
+function LoadingSpinner() {
+  return (
+    <div className={styles.spinnerArea}>
+      <div className={styles.spinnerInner}>
+        <div className={styles.spinnerCircle}></div>
+      </div>
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/src/components/LoadingSpinner/LoadingSpinner.module.css
+++ b/src/components/LoadingSpinner/LoadingSpinner.module.css
@@ -1,0 +1,38 @@
+.spinnerArea {
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+  overflow: hidden;
+  background: transparent;
+}
+
+.spinnerInner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform: translateZ(0) scale(1);
+  backface-visibility: hidden;
+  transform-origin: 0 0;
+}
+
+.spinnerCircle {
+  position: absolute;
+  height: 60%;
+  aspect-ratio: 1 / 1;
+  border: 0.3rem solid #ffffff;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+@keyframes spin {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}

--- a/src/layout/Emoji/EmojiDropDown.jsx
+++ b/src/layout/Emoji/EmojiDropDown.jsx
@@ -27,7 +27,6 @@ const DropDownContainer = styled.div`
   row-gap: 1rem;
   column-gap: 0.8rem;
 
-
   /* max-width: ${(props) => (props.isPC ? '31.2rem' : '24.8rem')};
   max-height: 13.4rem; */
 
@@ -38,7 +37,6 @@ const DropDownContainer = styled.div`
   ${shadow['mid']};
   ${blur};
 `;
-
 
 EmojiDropDown.propTypes = {
   emojiList: PropTypes.arrayOf(


### PR DESCRIPTION
### 이슈 번호

close #246 

### 변경 사항 요약

- Button 컴포넌트에 loading props가 추가되었습니다.

| prop | type | desc |
| ------- | ------- | ------- |
| `loading`    | `bool`| 로딩표시 유무 |

로딩값으로 true를 받으면 현재 버튼의 children 대신 로딩스피너를 보여줍니다.

- LoadingSpinner 컴포넌트가 추가되었습니다.
![image](https://github.com/user-attachments/assets/09499ef1-29c9-411f-8562-6311b1727212)

로딩스피너의 크기는 버튼의 세로길이 기준으로 변화하도록 설정하였습니다.


### 테스트 결과

![image](https://github.com/user-attachments/assets/26409e62-7de3-468b-99e7-d553c776b2bb)
