### PR TITLE
💄 드롭다운 레이아웃 수정하기

### DIFF
--- a/src/components/TextField/CommonInput.styles.js
+++ b/src/components/TextField/CommonInput.styles.js
@@ -19,15 +19,19 @@ export const StyledInput = css`
   color: ${({ theme }) => theme.secondary};
   background-color: ${({ theme }) => theme.background};
 
-  &:focus {
-    outline: none;
-    border: 0.2rem solid ${({ theme }) => theme.secondary};
-    color: ${({ theme }) => theme.text};
+  &:hover {
+    background-color: ${({ theme }) => theme.buttongray};
   }
 
-  &:active {
-    border: 0.2rem solid ${({ theme }) => theme.surface};
-    color: ${({ theme }) => theme.text};
+  &:active,
+  &:focus:active {
+    background-color: ${({ theme }) => theme.buttongray};
+    border-color: ${({ theme }) => theme.border};
+  }
+
+  &:focus {
+    border-color: ${({ theme }) => theme.secondary};
+    outline: none;
   }
 
   //focus, disabled 상태일 때는 hover하지 않기
@@ -38,6 +42,7 @@ export const StyledInput = css`
   &:disabled {
     border: 0.1rem solid ${({ theme }) => theme.border};
     background-color: ${({ theme }) => theme.surface};
+    cursor: not-allowed;
   }
 `;
 

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -43,8 +43,9 @@ import {
   DropdownList,
   DropdownItem,
   DropdownErrMessage,
-  IconArea,
+  span,
 } from './Dropdown.styles';
+import styles from './Dropdown.module.css';
 import useDeviceType from '../../hooks/useDeviceType';
 
 Dropdown.propTypes = {
@@ -108,14 +109,16 @@ function Dropdown({
       {/* icon 버튼인지 보통의 Dropdown인지 구분 */}
       {isIcon ? (
         <IconBtn
+          className={styles.iconBtn}
           onClick={() => setIsOpen(!isOpen)}
           $error={hasError.$error}
           disabled={disabled}>
-          <IconArea>{icon}</IconArea>
+          <span className={styles.iconArea}>{icon}</span>
         </IconBtn>
       ) : (
         <DropdownBtn
           type="button"
+          className={styles.dropdownBtn}
           onClick={() => setIsOpen(!isOpen)}
           $error={hasError.$error}
           disabled={disabled}
@@ -124,7 +127,12 @@ function Dropdown({
           {hasOptions.selectedOption.label
             ? hasOptions.selectedOption.label
             : hasOptions.selectedOption.value || hasOptions.options[0].label}
-          <ArrowImg src={ARROW_ICON} alt="arrow" isOpen={isOpen} />
+          <ArrowImg
+            className={styles.arrowImg}
+            src={ARROW_ICON}
+            alt="arrow"
+            isOpen={isOpen}
+          />
         </DropdownBtn>
       )}
 
@@ -135,10 +143,11 @@ function Dropdown({
       )}
 
       {isOpen && (
-        <DropdownList isIcon={isIcon}>
+        <DropdownList className={styles.dropdownList} isIcon={isIcon}>
           {hasOptions.options.map((option, index) => (
             <DropdownItem
               key={index}
+              className={styles.dropdownItem}
               onClick={() => handleSelect(option)}
               isIcon={isIcon}>
               {option.value}

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -103,7 +103,7 @@ function Dropdown({
   }, []);
 
   return (
-    <div ref={dropdownRef} className={styles.dropdownContainer}>
+    <div ref={dropdownRef}>
       {/* icon 버튼인지 보통의 Dropdown인지 구분 */}
       {isIcon ? (
         <IconBtn

--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -103,7 +103,7 @@ function Dropdown({
   }, []);
 
   return (
-    <div ref={dropdownRef}>
+    <div ref={dropdownRef} className={styles.dropdownContainer}>
       {/* icon 버튼인지 보통의 Dropdown인지 구분 */}
       {isIcon ? (
         <IconBtn

--- a/src/components/TextField/Dropdown.module.css
+++ b/src/components/TextField/Dropdown.module.css
@@ -23,10 +23,10 @@
 
 .dropdownList {
   position: absolute;
+  align-items: flex-end;
   z-index: 3;
   margin-top: 0.8rem;
   padding: 1rem 0.1rem;
-
   border: 0.1rem solid #ccc;
   border-radius: 0.8rem;
   cursor: pointer;

--- a/src/components/TextField/Dropdown.module.css
+++ b/src/components/TextField/Dropdown.module.css
@@ -23,7 +23,6 @@
 
 .dropdownList {
   position: absolute;
-  align-items: flex-end;
   z-index: 3;
   margin-top: 0.8rem;
   padding: 1rem 0.1rem;

--- a/src/components/TextField/Dropdown.module.css
+++ b/src/components/TextField/Dropdown.module.css
@@ -8,12 +8,28 @@
 }
 
 .iconBtn {
-  display: block;
-  max-width: 5.6rem;
-  max-height: 3.6rem;
-
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   padding: 0.6rem 1.6rem;
+  border-radius: 6px;
+
   cursor: pointer;
+}
+
+.iconArea {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+}
+
+.iconArea svg {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .arrowImg {
@@ -34,4 +50,10 @@
 .dropdownItem {
   padding: 1.2rem 1.6rem;
   cursor: pointer;
+}
+
+@media (max-width: 767px) {
+  .iconBtn {
+    padding: 0.6rem 0.6rem;
+  }
 }

--- a/src/components/TextField/Dropdown.styles.js
+++ b/src/components/TextField/Dropdown.styles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { font } from '../../styles/common/fonts.styles';
 import { StyledInput, StyledErrMessage } from './CommonInput.styles';
@@ -17,6 +17,11 @@ export const IconBtn = styled.img`
 
 export const DropdownList = styled.ul`
   width: ${({ isIcon }) => (isIcon ? '14rem' : '32rem')};
+  ${({ isIcon }) =>
+    isIcon &&
+    css`
+      right: 0px;
+    `}
 
   background-color: ${({ theme }) => theme.background};
   ${shadow['low']}
@@ -33,7 +38,7 @@ export const DropdownItem = styled.li`
 `;
 
 export const ArrowImg = styled.img`
-  transition: transform 0.3s ease; 
+  transition: transform 0.3s ease;
   transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(360deg)')};
 `;
 

--- a/src/components/TextField/Dropdown.styles.js
+++ b/src/components/TextField/Dropdown.styles.js
@@ -5,104 +5,41 @@ import { StyledInput, StyledErrMessage } from './CommonInput.styles';
 import { shadow } from '../../styles/layout/effect.styles';
 
 export const DropdownBtn = styled.button`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
   width: ${({ $deviceType }) => ($deviceType === 'mobile' ? '100%' : '32rem')};
-  padding: 1.2rem 1.6rem;
   ${StyledInput};
-  cursor: pointer;
 `;
 
 export const IconBtn = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 0.6rem 1.6rem;
-  border-radius: 6px;
   background-color: ${({ theme }) => theme.background};
   border: 1px solid ${({ theme }) => theme.border};
-  cursor: pointer;
   transition: all 0.3s;
   color: ${({ theme }) => theme.text};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.buttongray};
-  }
-
-  &:active,
-  &:focus:active {
-    background-color: ${({ theme }) => theme.buttongray};
-    border-color: ${({ theme }) => theme.border};
-  }
-
-  &:focus {
-    border-color: ${({ theme }) => theme.secondary};
-    outline: none;
-  }
-
-  &:disabled {
-    background-color: ${({ theme }) => theme.border};
-    color: ${({ theme }) => theme.whiteText};
-    cursor: not-allowed;
-  }
-  @media (max-width: 767px) {
-    padding: 0.6rem 0.6rem;
-  }
-`;
-
-export const IconArea = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2rem;
-  min-height: 2rem;
-
-  svg {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
+  ${StyledInput};
 `;
 
 export const ArrowImg = styled.img`
   transition: transform 0.3s ease;
   transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(360deg)')};
-  max-width: 1.6rem;
-  max-height: 1.6rem;
 `;
 
 //SECTION - Dropdown을 내렸을 때 나오는 요소들의 css
 
 export const DropdownList = styled.ul`
-  position: absolute;
-  z-index: 3;
-  margin-top: 0.8rem;
-  padding: 1rem 0.1rem;
-
   width: ${({ isIcon }) => (isIcon ? '14rem' : '32rem')};
   ${({ isIcon }) =>
     isIcon &&
     css`
       right: 0px;
     `}
-  border: 0.1rem solid #ccc;
-  border-radius: 0.8rem;
 
   background-color: ${({ theme }) => theme.background};
   ${shadow['low']}
-
-  cursor: pointer;
 `;
 
 export const DropdownItem = styled.li`
-  padding: 1.2rem 1.6rem;
   width: ${({ isIcon }) => (isIcon ? '13.8rem' : '31.6rem')};
 
   ${font[16]}
-  cursor: pointer;
 
   &:hover {
     background-color: ${({ theme }) => theme.surface};


### PR DESCRIPTION
드롭다운 레이아웃 수정하기

### 이슈 번호

close #262 

### 변경 사항 요약

<img width="698" alt="image" src="https://github.com/user-attachments/assets/97f70e39-5ddf-46fe-8cf0-a2046ce572fd">

- 기존의 아이콘 드롭다운이 오른쪽 그림처럼 버튼의 왼쪽 모서리에 맞춰 드롭다운이 된 점을 왼쪽 그림 처럼 오른쪽 모서리에 맞춰 드롭다운 되도록 수정했습니다. 

### 테스트 결과

베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.

- 아이콘 드롭다운 
![image](https://github.com/user-attachments/assets/a9c06b70-b36f-490f-8b46-f20c7d69573e)

- 기본 드롭다운도 문제 없습니당. 
![image](https://github.com/user-attachments/assets/837a62b6-d2cd-4e00-bd97-2b72a61366d4)

