### PR TITLE
💄 Css 분리 및 arrow 이미지 transform으로 사용

### DIFF
--- a/src/components/TextField/Dropdown.jsx
+++ b/src/components/TextField/Dropdown.jsx
@@ -43,7 +43,6 @@ import {
   DropdownList,
   DropdownItem,
   DropdownErrMessage,
-  span,
 } from './Dropdown.styles';
 import styles from './Dropdown.module.css';
 import useDeviceType from '../../hooks/useDeviceType';

--- a/src/layout/Emoji/EmojiDropDown.jsx
+++ b/src/layout/Emoji/EmojiDropDown.jsx
@@ -4,8 +4,7 @@ import { useState } from 'react';
 
 import { shadow, blur } from '../../styles/layout/effect.styles';
 import useDeviceType from '../../hooks/useDeviceType';
-import ArrowDown from '../../assets/icon-arrow_down.svg';
-import ArrowTop from '../../assets/icon-arrow_top.svg';
+import ARROW_ICON from '../../assets/icon-arrow_down.svg';
 import styles from './EmojiDropDown.module.css';
 import EmojiBadge from '../../components/Badge/EmojiBadge';
 
@@ -14,24 +13,17 @@ EmojiDropDown.propTypes = {
 };
 
 const DropDownContainer = styled.div`
-  position: absolute;
-  top: 110%;
-  right: 0;
-  display: grid;
   grid-template-columns: ${(props) =>
     props.isPC ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)'};
-  grid-template-rows: repeat(2, 1fr);
-  z-index: 10;
-
-  row-gap: 1rem;
-  column-gap: 0.8rem;
 
   padding: ${(props) => (props.isPC ? '2.4rem' : '1.5rem')};
-  border: 1px solid #b6b6b6;
-  border-radius: 8px;
-  background-color: var(--white);
   ${shadow['mid']};
   ${blur};
+`;
+
+const ArrowImg = styled.img`
+  transition: transform 0.3s ease;
+  transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(360deg)')};
 `;
 
 EmojiDropDown.propTypes = {
@@ -73,16 +65,17 @@ function EmojiDropDown({ emojiList = [] }) {
         </div>
         <div className={styles.imgWrapper} onClick={handleButton}>
           {emojiList.length >= 4 && (
-            <img
+            <ArrowImg
               className={styles.img}
-              src={isOpen ? ArrowTop : ArrowDown}
+              src={ARROW_ICON}
               alt="arrow"
+              isOpen={isOpen}
             />
           )}
         </div>
       </section>
       {isOpen && (
-        <DropDownContainer isPC={isPC}>
+        <DropDownContainer className={styles.dropDownContainer} isPC={isPC}>
           {emojiList.slice(0, isPC ? 8 : 6).map((emoji) => (
             <div className={styles.emojiBadge} key={emoji.id}>
               <EmojiBadge emoji={emoji.emoji} count={emoji.count} />

--- a/src/layout/Emoji/EmojiDropDown.module.css
+++ b/src/layout/Emoji/EmojiDropDown.module.css
@@ -1,4 +1,3 @@
-
 .Container {
   display: flex;
   flex-direction: column;
@@ -24,10 +23,25 @@
   cursor: pointer;
 }
 
-
 .img {
   width: 2.4rem;
   height: 2.4rem;
+}
+
+.dropDownContainer{
+  position: absolute;
+  top: 110%;
+  right: 0;
+  display: grid;
+  grid-template-rows: repeat(2, 1fr);
+  z-index: 10;
+
+  row-gap: 1rem;
+  column-gap: 0.8rem;
+
+  border: 1px solid #b6b6b6;
+  border-radius: 8px;
+  background-color: var(--white);
 }
 
 .emojiBadge {


### PR DESCRIPTION
css 분리 및 arrow 이미지 transform으로 사용

### 이슈 번호

close #267 

### 변경 사항 요약

- css 모듈 분리
- arrow 이미지 하나만 사용하고 transform으로 이용

### 테스트 결과

베이스(develop) 브랜치에 포함되기 위한 코드는 모두 정상적으로 작동이 되어야 합니다.

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/e8bf1a56-2a5d-4a28-a499-9ecb2f63b0a1">
