### PR TITLE
#272 롤링 페이퍼 생성 페이지 반응형 작업

### DIFF
--- a/src/components/BackgroundSelector/RadioCard.module.css
+++ b/src/components/BackgroundSelector/RadioCard.module.css
@@ -2,4 +2,10 @@
   display: flex;
   gap: 1.6rem;
   margin-top: 4.5rem;
+
+  @media (max-width: 767px) {
+    flex-wrap: wrap;
+    gap: 1.2rem;
+    margin-top: 2.8rem;
+  }
 }

--- a/src/components/BackgroundSelector/RadioCard.styles.js
+++ b/src/components/BackgroundSelector/RadioCard.styles.js
@@ -61,6 +61,11 @@ const StyleButton = styled.button`
     opacity: 1; /* 선택될 때 서서히 보이게 */
     transform: translate(-50%, -50%) scale(1); /* 원래 크기로 확대 */
   }
+
+  @media (max-width: 767px) {
+    width: 15.4rem;
+    height: 15.4rem;
+  }
 `;
 
 export { StyleButton };


### PR DESCRIPTION
### 이슈 번호

close #272 

### 변경 사항 요약

모바일 해상도에서의 반응형 작업이 누락되어, 추가하였습니다.

수정 부분은 탭 안의 컬러, 이미지 버튼 수정하였습니다.

### 테스트 결과
<img width="535" alt="스크린샷 2024-11-05 16 18 26" src="https://github.com/user-attachments/assets/fc61c0e5-b9fb-4e64-9789-c89d881d0b2b">
