### PR TITLE
#293 생성하기 수정하기 버튼 모바일에서 position

### DIFF
--- a/src/pages/MessagesAdd/MessagesAddPage.module.css
+++ b/src/pages/MessagesAdd/MessagesAddPage.module.css
@@ -12,4 +12,21 @@
 
 button[type='submit'] {
   margin-top: 6.2rem;
+  z-index: 10;
+}
+
+@media screen and (max-width: 1248px) {
+  button[type='submit'] {
+    width: 72rem;
+    position: fixed;
+    bottom: 2.4rem;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+@media screen and (max-width: 767px) {
+  button[type='submit'] {
+    width: 32rem;
+  }
 }


### PR DESCRIPTION
### 이슈 번호

close #293 

### 변경 사항 요약

태블릿, 모바일 해상도
롤링 페이퍼 생성 페이지, 메시지 생성, 수정 페이지의 버튼 `position: fixed` 적용하였습니다.

### 테스트 결과
<img width="469" alt="스크린샷 2024-11-07 00 39 38" src="https://github.com/user-attachments/assets/f66867d8-a964-4c94-bd4e-b08f4a843a1b">
<img width="468" alt="스크린샷 2024-11-07 00 40 05" src="https://github.com/user-attachments/assets/219f47d6-1442-49fd-ad26-78025e155ac9">
